### PR TITLE
Update lvs-tools.spec fix rpmbuild: error: Installed (but unpackaged) file(s) found Solution

### DIFF
--- a/dsnat-kernel-2.6.32-220.23.1.el6/dsnat_tools/rpm/lvs-tools.spec
+++ b/dsnat-kernel-2.6.32-220.23.1.el6/dsnat_tools/rpm/lvs-tools.spec
@@ -5,6 +5,7 @@ Summary: tools for manage lvs, include keepalived, ipvsadm and quagga
 Group: Taobao/Common
 URL: %{_svn_path} 
 %define _prefix /usr
+%define _unpackaged_files_terminate_build 0
 #Source:        %{name}-%{version}.tar.gz
 License:       GPL
 BuildRequires: kernel, kernel-devel, kernel-headers


### PR DESCRIPTION
rpmbuild: error: Installed (but unpackaged) file(s) found Solution
发现了制作RPM包的spec脚本中没有包含但又被安装的文件， 通过添加如下语句来解决
%define _unpackaged_files_terminate_build 0
